### PR TITLE
skip docker hub for rhel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,9 @@ jobs:
       - run:
           name: Publish
           command: |
-            make publish
+            if [ "$OS" != "rhel7" ]; then
+                make publish
+            fi
       - run:
           name: Publish to Red Hat
           command: |


### PR DESCRIPTION
Red Hat asked us to remove the docker hub repo for our RHEL build, since it violates the license agreement. This fixes the breaking build and skips pushing to docker hub for rhel images.